### PR TITLE
Add chained UTC matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New chained UTC matcher `.in_utc` ([@jas14])
+
+## [0.1.0] - 2022-07-06
+### Added
+- Base `be_an_iso8601_string` and alias `an_iso8601_string` matchers
+- Optional subsecond precision keyword argument
+- Chained subsecond precision matcher

--- a/lib/rspec/iso8601.rb
+++ b/lib/rspec/iso8601.rb
@@ -12,15 +12,21 @@ RSpec::Matchers.define :be_an_iso8601_string do |precision: nil|
     matches = actual.match(RSpec::ISO8601::REGEXP)
 
     precision ||= @precision
-    matches && (precision.nil? || (matches[:usec]&.length || 0) == precision)
+    matches &&
+      (precision.nil? || (matches[:usec]&.length || 0) == precision) &&
+      (@utc != true || matches[:offset] == "Z")
   end
 
   description do
-    "be an ISO8601 string#{" with precision #{precision}" unless precision.nil?}"
+    "be an ISO8601#{" UTC" if @utc} string#{" with precision #{precision}" unless precision.nil?}"
   end
 
   chain :with_precision do |digits|
     @precision = digits
+  end
+
+  chain :in_utc do
+    @utc = true
   end
 end
 

--- a/lib/rspec/iso8601/regexp.rb
+++ b/lib/rspec/iso8601/regexp.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module ISO8601
-    REGEXP = /^\d{4}-\d{2}-\d{2}T(?:\d{2}:){2}\d{2}(?:\.(?<usec>\d+))?(?:Z|[\-+]\d{2}:\d{2})$/.freeze
+    REGEXP = /^\d{4}-\d{2}-\d{2}T(?:\d{2}:){2}\d{2}(?:\.(?<usec>\d+))?(?<offset>Z|[\-+]\d{2}:\d{2})$/.freeze
   end
 end

--- a/spec/rspec/matchers_spec.rb
+++ b/spec/rspec/matchers_spec.rb
@@ -77,6 +77,25 @@ RSpec.describe "be_an_iso8601_string" do
     end
   end
 
+  describe "chaining UTC expectation" do
+    let(:in_utc) { "2022-07-01T15:30:01.670405Z" }
+    let(:not_in_utc) { "2022-07-01T15:30:01+04:00" }
+
+    it "works with precision chain" do
+      expect(in_utc).to be_an_iso8601_string.with_precision(6).in_utc
+      expect(in_utc).to be_an_iso8601_string.in_utc.with_precision(6)
+    end
+
+    it "fails with a useful message" do
+      expect do
+        expect(not_in_utc).to be_an_iso8601_string.in_utc
+      end.to fail_with("expected \"#{not_in_utc}\" to be an ISO8601 UTC string")
+    end
+
+    specify { expect(in_utc).to be_an_iso8601_string.in_utc }
+    specify { expect(not_in_utc).not_to be_an_iso8601_string.in_utc }
+  end
+
   describe "aliases" do
     it "is aliased as `an_iso8601_string`" do
       expect({ key: "2022-07-01T15:30:01Z" }).to match(key: an_iso8601_string)


### PR DESCRIPTION
Adds a `.in_utc` chain method to match the UTC ("zero") time zone offset. For example,

- `2022-07-01T15:30:01.670405Z` will match
- `2022-07-01T15:30:01+04:00` will not match